### PR TITLE
new cloudfront tracking url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,8 +19,8 @@ var LuckyOrange = module.exports = integration('Lucky Orange')
   .global('__wtw_lucky_is_segment_io')
   .global('__wtw_custom_user_data')
   .option('siteId', null)
-  .tag('http', '<script src="http://www.luckyorange.com/w.js?{{ cacheBuster }}">')
-  .tag('https', '<script src="https://ssl.luckyorange.com/w.js?{{ cacheBuster }}">');
+  .tag('http', '<script src="http://d10lpsik1i8c69.cloudfront.net/w.js?{{ cacheBuster }}">')
+  .tag('https', '<script src="https://d10lpsik1i8c69.cloudfront.net/w.js?{{ cacheBuster }}">');
 
 /**
  * Initialize.


### PR DESCRIPTION
We have switched to using a cloudfront url for added security and scalability.
